### PR TITLE
Fix Orientation change crash on Tablets.

### DIFF
--- a/library/src/main/java/de/mrapp/android/preference/activity/PreferenceActivity.java
+++ b/library/src/main/java/de/mrapp/android/preference/activity/PreferenceActivity.java
@@ -2649,7 +2649,7 @@ public abstract class PreferenceActivity extends AppCompatActivity
         outState.putParcelable(CURRENT_PREFERENCE_HEADER_EXTRA, currentHeader);
         outState.putParcelableArrayList(PREFERENCE_HEADERS_EXTRA, getListAdapter().getAllItems());
 
-        if (preferenceScreenFragment != null) {
+        if (preferenceScreenFragment != null && preferenceScreenFragment.isAdded()) {
             getFragmentManager().putFragment(outState, PREFERENCE_SCREEN_FRAGMENT_EXTRA,
                     preferenceScreenFragment);
         }


### PR DESCRIPTION
On Tablets greater then 7"s on the second orientation change the fragment would not be null however would not be added to the fragment manager causing a crash.

```
09-11 20:08:40.180 6675-6675/de.mrapp.android.preference.activity.example E/AndroidRuntime: FATAL EXCEPTION: main
                                                                                            Process: de.mrapp.android.preference.activity.example, PID: 6675
                                                                                            java.lang.IllegalStateException: Fragment IntroductionPreferenceFragment{10220286} is not currently in the FragmentManager
                                                                                                at android.app.FragmentManagerImpl.putFragment(FragmentManager.java:568)
                                                                                                at de.mrapp.android.preference.activity.PreferenceActivity.onSaveInstanceState(PreferenceActivity.java:2653)
                                                                                                at android.app.Activity.performSaveInstanceState(Activity.java:1298)
                                                                                                at android.app.Instrumentation.callActivityOnSaveInstanceState(Instrumentation.java:1288)
                                                                                                at android.app.ActivityThread.callCallActivityOnSaveInstanceState(ActivityThread.java:3958)
                                                                                                at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:3921)
                                                                                                at android.app.ActivityThread.access$900(ActivityThread.java:151)
                                                                                                at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1309)
                                                                                                at android.os.Handler.dispatchMessage(Handler.java:102)
                                                                                                at android.os.Looper.loop(Looper.java:135)
                                                                                                at android.app.ActivityThread.main(ActivityThread.java:5254)
                                                                                                at java.lang.reflect.Method.invoke(Native Method)
                                                                                                at java.lang.reflect.Method.invoke(Method.java:372)
                                                                                                at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
                                                                                                at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
```
